### PR TITLE
Remove weird characters at the end of the line

### DIFF
--- a/themes/vueNative/layout/index.ejs
+++ b/themes/vueNative/layout/index.ejs
@@ -69,8 +69,8 @@
       <div class="key-feature">
          <div class="title">Key features</div>
          <ul>
-            <li>Declarative rendering</li>
-            <li>  Two-way binding</li>
+            <li>Declarative rendering</li>
+            <li>  Two-way binding</li>
             <li>  Goodness of Vue ecosystem</li>
             <li>Compiles to React Native</li>
             <li> Completeness of React Native ecosystem</li>
@@ -79,8 +79,8 @@
       <div class="key-feature">
          <div class="title">Roadmap</div>
          <ul>
-            <li>Provide List without JSX</li>
-            <li>  Support for Animation</li>
+            <li>Provide List without JSX</li>
+            <li>  Support for Animation</li>
             <li> Better Debugging & Tracing</li>
          </ul>
       </div>


### PR DESCRIPTION
There was some weird characters in the Key features / Roadmap section that look bad on Chrome.