### PR TITLE
fixing example code for flat-list component

### DIFF
--- a/src/docs/basic-components.md
+++ b/src/docs/basic-components.md
@@ -132,17 +132,20 @@ One of the drawbacks using Flatlist is the renderItem method should return JSX w
 ```html
 <template>
     <flat-list
-        :data="{[{key: 'a'}, {key: 'b'}]}"
-        :render-item="{({item}) => renderList(item)"
+        :data="[{key: 'a'}, {key: 'b'}]"
+        :render-item="({item}) => renderList(item)"
     />
 </template>
 ```
 ```js
 <script>
+    import React from 'react';
+    import { Text } from 'react-native';
+    
     export default {
         methods: {
             renderList: (item) => {
-                return (<Text>{item}<Text>)
+                return (<Text>{item.key}<Text>)
             }
         }
     }


### PR DESCRIPTION
I've fixed flat-list code example part in the documentation, there's no need to wrap the `data` props and `render-item` props inside a curly brackets and the `renderList` method should have `{ item.key }` as `<Text/>` component child remembering react component can't render plain object as it's child.

Also we need to import react and the text component when using the JSX render functions inside the methods.