### PR TITLE
Fixing broken link in the Getting Started

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -8,7 +8,7 @@ order: 3
 
 ** Hello World In Vue Native **
 
-The easiest way to try out [Vue Native](https://vue-native.io/) is by building a Hello world app. The [Installation](installation.html) page provides setup of installing Vue Native and setup the project.
+The easiest way to try out [Vue Native](https://vue-native.io/) is by building a Hello world app. The [Installation](/docs/installation.html) page provides setup of installing Vue Native and setup the project.
 Create a .vue file and copy and paste the below content.
 
 ```html


### PR DESCRIPTION
I prefered using the absolute path rather than the relative one from the Getting Started, since the Installation page was in another directory.